### PR TITLE
Fix recent expl3 error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 tmp
 *.pdf
 *.tar.gz
+.idea

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-LaTeX Package : withargs 0.0.2
+LaTeX Package : withargs 0.2.0
 
-Last Modified : 2013-10-07
+Last Modified : 2016-12-19
 
 Author        : Michiel Helvensteijn  (www.mhelvens.net)
 
-===== Prerequisites =====
+
+##### Prerequisites #####
 
 To use this package, you need the following expl3 packages:
 * expl3
@@ -13,7 +14,8 @@ To use this package, you need the following expl3 packages:
 
 To generate the documentation some extra packages are needed.
 
-===== Installation =====
+
+##### Installation #####
 
 withargs.sty is provided directly in the package archive. Put
 it in a place where your LaTeX distribution can find it.
@@ -22,7 +24,8 @@ it in a place where your LaTeX distribution can find it.
  may use docstrip to remove the documentation, but you don't
  have to; it will just work the way it is)
 
-===== Documentation =====
+
+##### Documentation #####
 
 withargs.pdf is provided directly in the package archive. To
 generate the documentation yourself, run LaTeX on withargs.tex.
@@ -30,7 +33,8 @@ generate the documentation yourself, run LaTeX on withargs.tex.
 (withargs.tex does not contain the package code itself; it inputs
  withargs.sty directly to document the implementation)
 
-===== License =====
+
+##### License #####
 
 This material is subject to the LaTeX Project Public License. See
 http://www.ctan.org/tex-archive/help/Catalogue/licenses.lppl.html 

--- a/latex-withargs/README
+++ b/latex-withargs/README
@@ -1,10 +1,11 @@
-LaTeX Package : withargs 0.0.2
+LaTeX Package : withargs 0.2.0
 
-Last Modified : 2013-10-07
+Last Modified : 2016-12-19
 
 Author        : Michiel Helvensteijn  (www.mhelvens.net)
 
-===== Prerequisites =====
+
+##### Prerequisites #####
 
 To use this package, you need the following expl3 packages:
 * expl3
@@ -13,7 +14,8 @@ To use this package, you need the following expl3 packages:
 
 To generate the documentation some extra packages are needed.
 
-===== Installation =====
+
+##### Installation #####
 
 withargs.sty is provided directly in the package archive. Put
 it in a place where your LaTeX distribution can find it.
@@ -22,7 +24,8 @@ it in a place where your LaTeX distribution can find it.
  may use docstrip to remove the documentation, but you don't
  have to; it will just work the way it is)
 
-===== Documentation =====
+
+##### Documentation #####
 
 withargs.pdf is provided directly in the package archive. To
 generate the documentation yourself, run LaTeX on withargs.tex.
@@ -30,7 +33,8 @@ generate the documentation yourself, run LaTeX on withargs.tex.
 (withargs.tex does not contain the package code itself; it inputs
  withargs.sty directly to document the implementation)
 
-===== License =====
+
+##### License #####
 
 This material is subject to the LaTeX Project Public License. See
 http://www.ctan.org/tex-archive/help/Catalogue/licenses.lppl.html 

--- a/latex-withargs/archive
+++ b/latex-withargs/archive
@@ -9,31 +9,35 @@ FILES="$DOC.sty         \
        $DOC-packagedoc.cls  \
        README"
 
-VERSION=0.1.0
+VERSION=0.2.0
 
 ### Zero out the checksum value
 #
-sed -r -i.bak 's/\\CheckSum\{[0-9]*\}/\\CheckSum\{0\}/;' $DOC.sty
+sed -r -i.bak 's/\\CheckSum\{[0-9]*\}/\\CheckSum\{0\}/;' ${DOC}.sty
 
 ### First compilation
 #
-pdflatex $DOC
+pdflatex ${DOC}
 
 ### Find and put in the correct checksum
 #
-CHECKSUM=`cat $DOC.log | grep "The checksum should be" \
+CHECKSUM=`cat ${DOC}.log | grep "The checksum should be" \
                        | sed -r 's/[^0-9]*([0-9]*)[^0-9]*/\1/'`
-sed -r -i "s/\\CheckSum\{0\}/\\CheckSum\{$CHECKSUM\}/;" $DOC.sty
+sed -r -i "s/\\CheckSum\{0\}/\\CheckSum\{$CHECKSUM\}/;" ${DOC}.sty
 
 ### Create index
 #
-makeindex -s gglo.ist -o $DOC.gls $DOC.glo
-makeindex -s gind.ist -o $DOC.ind $DOC.idx
+makeindex -s gglo.ist -o ${DOC}.gls ${DOC}.glo
+makeindex -s gind.ist -o ${DOC}.ind ${DOC}.idx
 
 ### Final two compilations
 #
-pdflatex $DOC
-pdflatex $DOC
+pdflatex ${DOC}
+pdflatex ${DOC}
+
+### Reuse the README.md file for the archived plain-text README
+#
+cp ../README.md ./README
 
 ### Move all temporary stuff to the tmp folder
 #
@@ -52,11 +56,11 @@ mv *.bak tmp
 
 ### Tar it up
 #
-mkdir $DOC
-cp $FILES $DOC
-tar -czf $DOC-$VERSION.tar.gz $DOC
-rm -rf $DOC
+mkdir ${DOC}
+cp ${FILES} ${DOC}
+tar -czf ${DOC}-${VERSION}.tar.gz ${DOC}
+rm -rf ${DOC}
 
 ### Rename local pdf
 #
-mv $DOC.pdf $DOC-$VERSION.pdf
+mv ${DOC}.pdf ${DOC}-${VERSION}.pdf

--- a/latex-withargs/withargs.sty
+++ b/latex-withargs/withargs.sty
@@ -17,7 +17,7 @@
 %                                                                              %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% \fi %%%%
 
-% \CheckSum{115}
+% \CheckSum{117}
 %
 % \CharacterTable
 %  {Upper-case    \A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -142,7 +142,7 @@
 %  longer than |#1| --- a prefix.
 %  
 %    \begin{macrocode}
-\cs_new:Nn \__withargs_var:nx {
+\cs_new:Nn \__withargs_var:nn {
   \cs_generate_variant:cx
     { withargs : \prg_replicate:nn{#1}{n} n }
     { #2 n }
@@ -155,6 +155,7 @@
 }
 %    \end{macrocode}
 %    \uninteresting\begin{macrocode}
+\cs_generate_variant:Nn \__withargs_var:nn {nx}
 \cs_generate_variant:Nn \cs_generate_variant:Nn {cx}
 %    \end{macrocode}
 %

--- a/latex-withargs/withargs.sty
+++ b/latex-withargs/withargs.sty
@@ -1,6 +1,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% \iffalse %%%%
 %                                                                              %
-%  Copyright (c) 2013 - Michiel Helvensteijn   (www.mhelvens.net)              %
+%  Copyright (c) 2016 - Michiel Helvensteijn   (www.mhelvens.net)              %
 %                                                                              %
 %  This work may be distributed and/or modified under the conditions           %
 %  of the LaTeX Project Public License, either version 1.3 of this             %
@@ -46,7 +46,7 @@
 %    \begin{macrocode}
 \NeedsTeXFormat{LaTeX2e}
 \RequirePackage{expl3}
-\ProvidesExplPackage{withargs}{2015/09/07}{0.1.0}
+\ProvidesExplPackage{withargs}{2016/12/19}{0.2.0}
   {an inline construct for passing token lists as TeX parameters}
 %    \end{macrocode}
 %
@@ -328,5 +328,3 @@
 %    \end{macrocode}
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-

--- a/latex-withargs/withargs.tex
+++ b/latex-withargs/withargs.tex
@@ -1,6 +1,6 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% \iffalse %%%%
 %                                                                              %
-%  Copyright (c) 2013 - Michiel Helvensteijn   (www.mhelvens.net)              %
+%  Copyright (c) 2016 - Michiel Helvensteijn   (www.mhelvens.net)              %
 %                                                                              %
 %  This work may be distributed and/or modified under the conditions           %
 %  of the LaTeX Project Public License, either version 1.3 of this             %
@@ -41,6 +41,9 @@
   {renamed package to \texttt{withargs}}
   
 \changes{0.1.0}{2015/09/07}
+  {adjusted code to new version of expl3}
+
+\changes{0.2.0}{2016/12/19}
   {adjusted code to new version of expl3}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Fixes mhelvens/latex-withargs#2.

This is the most straightforward fix I could find; I contemplated using `\cs_new:Npn`, but I didn't want to have to alter the code *too* significantly.  This way, the change is near-trivial, and it still expresses the correct intent.